### PR TITLE
Reconfigure nginx to serve new webui deployment

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       - 80:80
       - 443:443
     volumes:
-      # Mount named volume to share files between web UI and nginx proxy
-      - app-volume:/usr/share/nginx/html:rw
       # Mount the nginx folder with the configuration
       - ./nginx:/etc/nginx:ro
       # Static files for django
@@ -35,10 +33,8 @@ services:
       - django-static-volume:/django/static
 
   winearth-webui:
-    image: ghcr.io/windows-on-earth/winearth-webui:1.0.1
+    image: ghcr.io/windows-on-earth/winearth-webui:1.0.2
     restart: "no"
-    volumes:
-      - app-volume:/app/dist
     depends_on:
       winearth-api-server:
         condition: service_started
@@ -54,5 +50,4 @@ services:
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot --webroot-path /var/www/certbot/; sleep 12h & wait $${!}; done;'"
 
 volumes:
-  app-volume:
   django-static-volume:

--- a/docker-compose/nginx/sites-enabled/winearth.conf
+++ b/docker-compose/nginx/sites-enabled/winearth.conf
@@ -1,4 +1,9 @@
 # nginx/sites-available/winearth.conf
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=STATIC:10m inactive=7d use_temp_path=off;
+
+upstream winearth-webui {
+    server winearth-webui:3000;
+}
 
 server {
     listen 443 ssl;
@@ -21,19 +26,57 @@ server {
     error_log /var/log/winearth/error.log warn;
     root /usr/share/nginx/html;
 
+    gzip on;
+    gzip_comp_level 4;
+    gzip_types text/css application/javascript image/svg+xml;
+
     # Redirect to the discovery webui
     location / {
-        try_files $uri $uri/ /index.html;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+
+        gzip_proxied any;
+
+        proxy_pass http://winearth-webui;
     }
 
-    location ~ ^/movies/?$ {
-        rewrite ^/movies/?$ /movies.html break;
+    location /_next/static {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_cache STATIC;
+
+        gzip_proxied any;
+        
+        proxy_pass http://winearth-webui;
+
+        # For testing cache - remove before deploying to production
+        add_header X-Cache-Status $upstream_cache_status;
     }
 
-    location /movie/ {
-        rewrite ^/movie/(.*)$ /movie/$1.html break;
-    }
+    location /static {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_cache STATIC;
+        proxy_ignore_headers Cache-Control;
+        proxy_cache_valid 60m;
 
+        gzip_proxied any;
+
+        proxy_pass http://winearth-webui;
+
+        # For testing cache - remove before deploying to production
+        add_header X-Cache-Status $upstream_cache_status;
+    }
+    
     # Serve the django static files
     location /django-static/ {
         root /static/;

--- a/docker-compose/nginx/sites-enabled/winearth.conf-dev
+++ b/docker-compose/nginx/sites-enabled/winearth.conf-dev
@@ -1,4 +1,9 @@
 # nginx/sites-available/winearth.conf
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=STATIC:10m inactive=7d use_temp_path=off;
+
+upstream winearth-webui {
+    server winearth-webui:3000;
+}
 
 server {
     listen 80;
@@ -12,17 +17,55 @@ server {
     error_log /var/log/winearth/error.log warn;
     root /usr/share/nginx/html;
 
+    gzip on;
+    gzip_comp_level 4;
+    gzip_types text/css application/javascript image/svg+xml;
+
     # Redirect to the discovery webui
     location / {
-        try_files $uri $uri/ /index.html;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+
+        gzip_proxied any;
+
+        proxy_pass http://winearth-webui;
     }
     
-    location ~ ^/movies/?$ {
-        rewrite ^/movies/?$ /movies.html break;
+    location /_next/static {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_cache STATIC;
+
+        gzip_proxied any;
+        
+        proxy_pass http://winearth-webui;
+
+        # For testing cache - remove before deploying to production
+        add_header X-Cache-Status $upstream_cache_status;
     }
 
-    location /movie/ {
-        rewrite ^/movie/(.*)$ /movie/$1.html break;
+    location /static {
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_cache STATIC;
+        proxy_ignore_headers Cache-Control;
+        proxy_cache_valid 60m;
+
+        gzip_proxied any;
+
+        proxy_pass http://winearth-webui;
+
+        # For testing cache - remove before deploying to production
+        add_header X-Cache-Status $upstream_cache_status;
     }
 
     # Serve the django static files


### PR DESCRIPTION
Web UI is now using a server to deploy; configured nginx to reverse proxy the app Added proxy settings for cache support
Updated docker compose versions for new ghcr
Removed unneeded volume for app in docker compose